### PR TITLE
Trigger a tree if mid-session

### DIFF
--- a/decisiontree/app.py
+++ b/decisiontree/app.py
@@ -23,23 +23,27 @@ class App(AppBase):
 
     def handle(self, msg):
         '''
-        The handle function should return True: this tells RapidSMS that other apps need not handle the message. 
+        The handle function should return True or False.
+        True tells RapidSMS that the message has been handled.
+        False tell RapidSMS that another app should handle it. 
         https://rapidsms.readthedocs.io/en/develop/tutorial/tutorial02.html#handling-a-message 
         
         msg is an instance of a Rapidsms IncomingMessage object.
         https://github.com/rapidsms/rapidsms/blob/347a4d05566ef68d9f494d329cbdc85ce28e811c/rapidsms/messages/incoming.py#L9  
         '''
-        sessions = msg.connection.session_set.open().select_related('state')
-
-        # Try to find a survey/tree with the incoming message
-        # If a tree does not exist and the user has not started a session, return False. 
+        # Try to find a survey/tree with the incoming message, i.e., trigger word.
+        # If found, then the user wants to (re)start the survey.
         survey = get_survey(msg.text, msg.connection)
         if survey:
             self.start_tree(survey, msg.connection, msg)
             return True 
 
-        if sessions.count() == 0 and not survey:
+        sessions = msg.connection.session_set.open().select_related('state')
+        if not survey and sessions.count() == 0:
             logger.info('Tree not found: %s', msg.text)
+            # Error message handled by the default RapidSMS app
+            # https://github.com/rapidsms/rapidsms/blob/master/docs/ref/settings.rst#default_response
+            # TODO: customize it.
             return False
 
         # the caller is part-way though a question


### PR DESCRIPTION
This PR handles issue #5.

I can imagine [another way to deal with this](https://github.com/datamade/rapidsms-decisiontree-app/pull/8), i.e., allowing for multiple trigger words per Tree. 

However, that seems unnecessary at this point in development, so I am taking the simplest path forward: in short, checking if the user message is [the trigger word associated with a Tree](https://github.com/datamade/rapidsms-decisiontree-app/blob/master/decisiontree/utils.py#L9), and if so, clearing all sessions and sending the user (back) to the top of the tree. 