### PR TITLE
String representation as name, not message text

### DIFF
--- a/decisiontree/models.py
+++ b/decisiontree/models.py
@@ -135,7 +135,7 @@ class TreeState(models.Model):
         verbose_name = 'survey state'
 
     def __str__(self):
-        return self.message.text
+        return self.name
 
     def add_all_unique_children(self, added):
         """


### PR DESCRIPTION
Previously, the string representation of the State model rendered the State's related message text: this can be confusing, particularly when multiple states relate to the same message ([as when rendering the Path form](https://github.com/datamade/rapidsms-decisiontree-app/blob/master/decisiontree/forms/forms.py#L72)).

This PR changes the string representation to the State's name. 

Handles issues #11 



