### PR TITLE
Order message answers by the selection number

### DIFF
--- a/decisiontree/app.py
+++ b/decisiontree/app.py
@@ -250,7 +250,7 @@ class App(AppBase):
         raise Exception("Don't know how to process answer type: %s", answer.type)
 
     def _concat_answers(self, response, state):
-        transition_set = Transition.objects.filter(current_state=state)
+        transition_set = Transition.objects.filter(current_state=state).order_by('answer')
         for t in transition_set:
             response += t.answer.helper_text()
 


### PR DESCRIPTION
This PR puts possible answers in correct order.

E.g., returns this:

<img width="271" alt="screen shot 2018-08-20 at 11 58 21 am" src="https://user-images.githubusercontent.com/13078679/44354817-7457be80-a470-11e8-9c27-bfb30b8d8ddb.png">

Not this:
<img width="266" alt="screen shot 2018-08-20 at 11 58 36 am" src="https://user-images.githubusercontent.com/13078679/44354826-7a4d9f80-a470-11e8-8df4-b14a4d1d09ad.png">
