### PR TITLE
Increase char limit for message

### DIFF
--- a/decisiontree/app.py
+++ b/decisiontree/app.py
@@ -41,10 +41,6 @@ class App(AppBase):
         sessions = msg.connection.session_set.open().select_related('state')
         if not survey and sessions.count() == 0:
             logger.info('Tree not found: %s', msg.text)
-            # Error message handled by the default RapidSMS app
-            # https://github.com/rapidsms/rapidsms/blob/master/docs/ref/settings.rst#default_response
-            # TODO: customize it.
-
 
             return False
 

--- a/decisiontree/app.py
+++ b/decisiontree/app.py
@@ -44,6 +44,8 @@ class App(AppBase):
             # Error message handled by the default RapidSMS app
             # https://github.com/rapidsms/rapidsms/blob/master/docs/ref/settings.rst#default_response
             # TODO: customize it.
+
+
             return False
 
         # the caller is part-way though a question
@@ -169,6 +171,7 @@ class App(AppBase):
         if tree.trigger in self.session_listeners:
             for func in self.session_listeners[tree.trigger]:
                 func(session, False)
+
         self._send_message(session, msg)
 
     def _send_message(self, session, msg=None):

--- a/decisiontree/forms/forms.py
+++ b/decisiontree/forms/forms.py
@@ -78,7 +78,9 @@ class PathCreateUpdateForm(TenancyModelForm):
         self.fields['tags'].label = 'Auto tags'
 
 class MessageCreateUpdateForm(TenancyModelForm):
-    max_length = forms.ChoiceField(choices=MAX_LENGTH_CHOICES)
+    max_length = forms.ChoiceField(choices=((500, 'English'),
+                                            (500, 'Arabic'),
+                                            ))
 
     class Meta:
         model = models.Message


### PR DESCRIPTION
The newer version of Twilio ([which the app now uses](https://github.com/datamade/rapidsms-twilio/pull/2)) does not strictly limit message length. 

The Message model has an increased character length of 500 (I did this in a previous PR). This PR updates the form accordingly. 