### PR TITLE
Lowcase message text

### DIFF
--- a/decisiontree/app.py
+++ b/decisiontree/app.py
@@ -33,6 +33,7 @@ class App(AppBase):
         '''
         # Try to find a survey/tree with the incoming message, i.e., trigger word.
         # If found, then the user wants to (re)start the survey.
+        msg.text = msg.text.lower()
         survey = get_survey(msg.text, msg.connection)
         if survey:
             self.start_tree(survey, msg.connection, msg)


### PR DESCRIPTION
The trigger word and answer possibilities will be numeric codes. However, we may decide to have 'y' and 'n' as answers: the app should be case insensitive, in the event of autocorrection.